### PR TITLE
updated google apis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.1, 2020-08-26
+
+- Uses the latest version of Google's API module (59.0.0). Compatibility has been verified.
+
 ## 1.1.0, 2020-07-01
 
 - Documented how to override Google's automatic guesses that can result in the loss of leading zeroes from phone numbers.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe-forms-submit-google",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Google Sheets submission for Apostrophe Forms",
   "main": "index.js",
   "scripts": {
@@ -26,16 +26,16 @@
     "eslint": "^4.15.0",
     "eslint-config-apostrophe": "^2.0.2",
     "eslint-config-standard": "^11.0.0-beta.0",
-    "eslint-plugin-import": "^2.16.0",
+    "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-node": "^5.2.1",
     "eslint-plugin-promise": "^3.6.0",
     "eslint-plugin-standard": "^3.0.1"
   },
   "dependencies": {
-    "googleapis": "^39.2.0",
+    "googleapis": "^59.0.0",
     "lodash.has": "^4.5.2",
     "request": "^2.88.0",
-    "request-promise": "^4.2.4"
+    "request-promise": "^4.2.6"
   },
   "peerDependencies": {
     "apostrophe-forms": "1.x",


### PR DESCRIPTION
I verified that it still works. Client identified that we were using an old major version of google's API module.

Google's decision to put all of their APIs in one npm wrapper produces a ferocious rate of bc breaking new releases. Depending on the difficulty, in future we might consider just speaking REST to google directly as the API itself provides long term bc.